### PR TITLE
Feature/cloud 450 ecr create script

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,6 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/nodejs-action:v1.1.1
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/nodejs-action:v1.1.0
   env:
     GITHUB_TOKEN: ${{ inputs.github_token }}

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,6 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/nodejs-action:v1.1.0
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/nodejs-action:sha-6e75d987d2326433553733890c2111e9fa800a24 #v1.1.0
   env:
     GITHUB_TOKEN: ${{ inputs.github_token }}

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,6 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/nodejs-action:v1.1.0
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/nodejs-action:v1.1.1
   env:
     GITHUB_TOKEN: ${{ inputs.github_token }}

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,6 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: docker://public.ecr.aws/p4v7w0a5/lazy/nodejs-action:sha-6e75d987d2326433553733890c2111e9fa800a24 #v1.1.0
+  image: docker://public.ecr.aws/p4v7w0a5/lazy/nodejs-action:v1.1.1
   env:
     GITHUB_TOKEN: ${{ inputs.github_token }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,9 +17,7 @@ cd "$GITHUB_WORKSPACE"
 echo "Current directory: $(pwd)"
 
 echo "Cloning into actions-collection..."
-git clone -b v1 https://github.com/variant-inc/actions-collection.git ./actions-collection
-# shellcheck disable=SC1091
-source ./actions-collection/collections.sh
+git clone -b feature/CLOUD-450-ecr-create-script https://github.com/variant-inc/actions-collection.git ./actions-collection
 
 export AWS_WEB_IDENTITY_TOKEN_FILE="/token"
 echo "$AWS_WEB_IDENTITY_TOKEN" >> "$AWS_WEB_IDENTITY_TOKEN_FILE"
@@ -47,13 +45,13 @@ sh -c "/scripts/coverage_scan.sh"
 echo "End: Sonar Scan"
 
 echo "Start: Checking ECR Repo"
-ecr_create "$INPUT_ECR_REPOSITORY"
+./actions-collection/scripts/ecr_create.sh "$INPUT_ECR_REPOSITORY"
 echo "End: Checking ECR Repo"
 
 echo "Container Push: $INPUT_CONTAINER_PUSH_ENABLED"
 if [ "$INPUT_CONTAINER_PUSH_ENABLED" = 'true' ]; then
   echo "Start: Publish Image to ECR"
-  /scripts/publish.sh
+  ./actions-collection/scripts/publish.sh
   echo "End: Publish Image to ECR"
 fi
 


### PR DESCRIPTION
# Description

Moved ecr_create() function to ecr_creat.sh in scripts. This is called in actions-dotnet and actions-nodejs.

Feature [CLOUD-450](https://usxtech.atlassian.net/browse/CLOUD-450)

## Type of change
- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

- [x] Sanity Testing
- https://github.com/variant-inc/demo-nodejs-app/runs/2877702634?check_suite_focus=true
  - Line 492-505 displays ecr_create.sh displays repo already created. However the pipeline fails due to trivy_scan.sh
  - 
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added documentation to test
