### PR TITLE
Feature/cloud 1090 add quality wait

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,6 @@ inputs:
     default: "."
 runs:
   using: "docker"
-  image: "docker://public.ecr.aws/p4v7w0a5/lazy/nodejs-action:v1.2.0"
+  image: "docker://public.ecr.aws/p4v7w0a5/lazy/nodejs-action:v1.3.0"
   env:
     GITHUB_TOKEN: ${{ inputs.github_token }}

--- a/scripts/sonarscan.sh
+++ b/scripts/sonarscan.sh
@@ -9,6 +9,11 @@ if [ -n "$INPUT_SONAR_PROJECT_KEY" ]; then
   SONAR_PROJECT_KEY="$INPUT_SONAR_PROJECT_KEY"
 fi
 
+wait_flag="false"
+if [ "$BRANCH_NAME" == "master" ] || [ "$BRANCH_NAME" == "main" ]; then
+  wait_flag="true"
+fi
+
 sonar_args="-Dsonar.organization=$SONAR_ORGANIZATION \
             -Dsonar.projectKey=$SONAR_PROJECT_KEY \
             -Dsonar.projectBaseDir=$INPUT_SONAR_PROJECT_BASE_DIR \
@@ -16,7 +21,8 @@ sonar_args="-Dsonar.organization=$SONAR_ORGANIZATION \
             -Dsonar.login=$SONAR_TOKEN \
             -Dsonar.scm.disabled=true \
             -Dsonar.scm.revision=$GITHUB_SHA \
-            -Dsonar.javascript.lcov.reportPaths=$INPUT_SONAR_PROJECT_BASE_DIR/coverage/lcov.info"
+            -Dsonar.javascript.lcov.reportPaths=$INPUT_SONAR_PROJECT_BASE_DIR/coverage/lcov.info \
+            -Dsonar.qualitygate.wait=$wait_flag"
 
 if [ "$PULL_REQUEST_KEY" = null ]; then
   echo "Sonar run when pull request key is null."


### PR DESCRIPTION
# Description

Add qualitygate.wait flag to sonar scan if on master branch.

Note: Left check for test branch. Will remove that check after testing is complete. Will also change image tag back after approval. Also removed unit test check for testing, will add back before merging.

Fixes [#1090](https://usxtech.atlassian.net/browse/CLOUD-1090)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Test Cases:
```yaml
- Fail on master:
  - Steps: Commit a dummy commit to demo-nodejs-app test/CLOUD-1090-test-sonar, leaving dummy file in.
  - Expected: Sonar quality gate fails, failing the build.
  - Actual: [INSERT RESULTS HERE]
- Pass on master:
  - Steps: Commit a dummy commit to demo-nodejs-app test/CLOUD-1090-test-sonar, removing dummy function in.
  - Expected: Sonar quality gate passes, build continues. (May fail for another reason)
  - Actual: [INSERT RESULTS HERE]
- Fail on feature:
  - Create a new test branch with a different name in demo-nodejs-app. Make sure actions-dotnet step points to this branch. Add a dummy file that will fail sonar quality gate. You can check the branch from previous steps for example.
  - Expected: Sonar quality gate fails, but build continues. (May fail for another reason)
  - Actual: [INSERT RESULTS HERE]
- Pass on feature:
  - Create a new test branch with a different name in demo-nodejs-app. Make sure actions-dotnet step points to this branch. Create a dummy commit.
  - Expected: Sonar quality gate passes, build continues. (May fail for another reason)
  - Actual: [INSERT RESULTS HERE]
```
*Note for testing. demo-nodejs-app branch "test/CLOUD-1090-test-sonar" will be used to simulate master branch scenarios.

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added documentation to test
