### PR TITLE
Feature/cloud 1476 sonar fail logs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,6 @@ inputs:
     default: "."
 runs:
   using: "docker"
-  image: "docker://public.ecr.aws/p4v7w0a5/lazy/nodejs-action:v1.3.0"
+  image: "docker://public.ecr.aws/p4v7w0a5/lazy/nodejs-action:v1.3.1"
   env:
     GITHUB_TOKEN: ${{ inputs.github_token }}

--- a/scripts/sonarscan.sh
+++ b/scripts/sonarscan.sh
@@ -4,6 +4,30 @@ set -e
 
 SONAR_ORGANIZATION="$SONAR_ORG"
 
+sonar_logout() {
+  exit_code=$?
+  echo "Exit code is $exit_code"
+  if [ "$exit_code" -eq 0 ]; then
+    echo -e "\e[1;32m ________________________________________________________________\e[0m"
+    echo -e "\e[1;32m Quality Gate Passed.\e[0m"
+    echo -e "\e[1;32m ________________________________________________________________\e[0m"
+  elif [ "$exit_code" -gt 0 ]; then
+    set -e
+    echo -e "\e[1;31m ________________________________________________________________\e[0m"
+    echo -e "\e[1;31m ________________________________________________________________\e[0m"
+    echo ""
+    echo ""
+    echo -e "\e[1;31m Sonar Quality Gate failed in $SONAR_PROJECT_KEY.\e[0m"
+    echo ""
+    echo ""
+    echo -e "\e[1;31m ________________________________________________________________\e[0m"
+    echo -e "\e[1;31m ________________________________________________________________\e[0m"
+    exit 1 
+  fi
+}
+
+trap "sonar_logout" EXIT
+
 if [ -n "$INPUT_SONAR_PROJECT_KEY" ]; then
   echo "Changing project key to $INPUT_SONAR_PROJECT_KEY"
   SONAR_PROJECT_KEY="$INPUT_SONAR_PROJECT_KEY"
@@ -24,6 +48,7 @@ sonar_args="-Dsonar.organization=$SONAR_ORGANIZATION \
             -Dsonar.javascript.lcov.reportPaths=$INPUT_SONAR_PROJECT_BASE_DIR/coverage/lcov.info \
             -Dsonar.qualitygate.wait=$wait_flag"
 
+
 if [ "$PULL_REQUEST_KEY" = null ]; then
   echo "Sonar run when pull request key is null."
   eval "sonar-scanner $sonar_args -Dsonar.branch.name=$BRANCH_NAME"
@@ -32,4 +57,3 @@ else
   echo "Sonar run when pull request key is not null."
   eval "sonar-scanner $sonar_args -Dsonar.pullrequest.key=$PULL_REQUEST_KEY"
 fi
-


### PR DESCRIPTION
# Description

Added sonar logs.
Image tag will change from `v1.3.0` -> `v1.3.1`
Commented out yarn test since it was failing for demo-nodejs-app. Will Revert after approval.
Fixes [#1476](https://drivevariant.atlassian.net/browse/CLOUD-1476)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

[Sonar Link](https://sonarcloud.io/organizations/variant/quality_gates/show/56084)
[Demo App Main](https://github.com/variant-inc/demo-nodejs-app/tree/main)

- [x] Sanity Testing
```yaml
Test Case 1: Sonar Pass
  1. Navigate to Sonar Link
  2. Remove varaint-inc_demo-nodejs-app from Test Quality Gate Fail
  3. Add variant-inc_demo-nodejs-app to Test Quality Gate Pass
  4.  Checkout "main" branch from demo-nodejs-app
  5. Push Dummy commit
Result
  - Expected: See Sonar Pass with pretty green logs "Quality Gate Passed".
  - https://github.com/variant-inc/demo-nodejs-app/runs/5233611472?check_suite_focus=true#step:5:466
  - Actual: Pass (Naveen)


Test Case 2: Sonar Fail
  1. Navigate to Sonar Link
  2. Remove varaint-inc_demo-nodejs-app to Test Quality Gate Pass
  3. Add variant-inc_demo-nodejs-app to Test Quality Gate Fail
  2. Checkout "main" branch from demo-nodejs-app
  3. Comment out any .js file
  3. Push Dummy commit
Result
  - Expected: See Sonar Fail with pretty red logs "Sonar Quality Gate failed in $SONAR_PROJECT_KEY". 
  - https://github.com/variant-inc/demo-nodejs-app/runs/5233501018?check_suite_focus=true#step:5:471
  - Actual: Pass (Naveen)
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
