### PR TITLE
F/cloud 1740 skip image

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,6 @@ inputs:
     default: "."
 runs:
   using: "docker"
-  image: "docker://public.ecr.aws/p4v7w0a5/lazy/nodejs-action:v1.5.0"
+  image: "docker://public.ecr.aws/p4v7w0a5/lazy/nodejs-action:test-latest"
   env:
     GITHUB_TOKEN: ${{ inputs.github_token }}

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,6 @@ inputs:
     default: "."
 runs:
   using: "docker"
-  image: "docker://public.ecr.aws/p4v7w0a5/lazy/nodejs-action:test-latest"
+  image: "docker://public.ecr.aws/p4v7w0a5/lazy/nodejs-action:v1.5.1"
   env:
     GITHUB_TOKEN: ${{ inputs.github_token }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,7 @@ echo "Current directory: $(pwd)"
 git config --global --add safe.directory /github/workspace
 
 echo "Cloning into actions-collection..."
-git clone -b v1 https://github.com/variant-inc/actions-collection.git ./actions-collection
+git clone -b f/CLOUD-1740-skip-image-push https://github.com/variant-inc/actions-collection.git ./actions-collection
 
 echo "---Start: Pretest script"
 chmod +x ./actions-collection/scripts/pre_test.sh
@@ -46,9 +46,9 @@ echo "Start: Enable sonar"
 pwsh ./actions-collection/scripts/enable_sonar.ps1
 echo "End: Enable sonar"
 
-echo "Start: yarn test"
-yarn run "$INPUT_NPM_TEST_SCRIPT_NAME"
-echo "End: yarn test"
+# echo "Start: yarn test"
+# yarn run "$INPUT_NPM_TEST_SCRIPT_NAME"
+# echo "End: yarn test"
 
 echo "Start: Check sonar run"
 skip_sonar_run=$(pwsh ./actions-collection/scripts/skip_sonar_run.ps1)
@@ -69,6 +69,6 @@ if [ "$INPUT_CONTAINER_PUSH_ENABLED" = 'true' ]; then
   ./actions-collection/scripts/ecr_create.sh "$INPUT_ECR_REPOSITORY"
   echo "End: Checking ECR Repo"
   echo "Start: Publish Image to ECR"
-  ./actions-collection/scripts/publish.sh
+  pwsh ./actions-collection/scripts/publish.ps1
   echo "End: Publish Image to ECR"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,7 @@ echo "Current directory: $(pwd)"
 git config --global --add safe.directory /github/workspace
 
 echo "Cloning into actions-collection..."
-git clone -b f/CLOUD-1740-skip-image-push https://github.com/variant-inc/actions-collection.git ./actions-collection
+git clone -b v1 https://github.com/variant-inc/actions-collection.git ./actions-collection
 
 echo "---Start: Pretest script"
 chmod +x ./actions-collection/scripts/pre_test.sh
@@ -46,9 +46,9 @@ echo "Start: Enable sonar"
 pwsh ./actions-collection/scripts/enable_sonar.ps1
 echo "End: Enable sonar"
 
-# echo "Start: yarn test"
-# yarn run "$INPUT_NPM_TEST_SCRIPT_NAME"
-# echo "End: yarn test"
+echo "Start: yarn test"
+yarn run "$INPUT_NPM_TEST_SCRIPT_NAME"
+echo "End: yarn test"
 
 echo "Start: Check sonar run"
 skip_sonar_run=$(pwsh ./actions-collection/scripts/skip_sonar_run.ps1)
@@ -62,7 +62,6 @@ if [ "$skip_sonar_run" != 'True' ]; then
 else
   echo "End: Skipping sonar run"
 fi
-
 
 echo "Container Push: $INPUT_CONTAINER_PUSH_ENABLED"
 if [ "$INPUT_CONTAINER_PUSH_ENABLED" = 'true' ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,6 +63,7 @@ else
   echo "End: Skipping sonar run"
 fi
 
+
 echo "Container Push: $INPUT_CONTAINER_PUSH_ENABLED"
 if [ "$INPUT_CONTAINER_PUSH_ENABLED" = 'true' ]; then
   echo "Start: Checking ECR Repo"


### PR DESCRIPTION
# Description

Skip ecr image if it is already generated.

Fixes [#22](https://usxtech.atlassian.net/browse/CLOUD-1740)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

[Demo nodejs app](https://github.com/variant-inc/demo-nodejs-app/tree/test/skip-ecr)

```yaml
Test Case 1: ECR image should be pushed and existing flow should remain same
  1. Navigate to demo app branch create a commit.
  2. Should trigger run and existing flow should remain same and push image to ECR
  3. Look for log "New image, proceeding to docker push"

Result
  - Expected: See image is pushed with that commit.
  - Actual: 

Test Case 2: Skip image push when re-run
  1. Navigate to actions and pick the run previously created.
  2. Re-run the build, it should trigger the run and should not push image to ECR.
  4. Look for log "Image already pushed. Skipping docker push"

Result
  - Expected: ECR image push should be skipped.
```

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added documentation to test
